### PR TITLE
Lock Cypress to version 9

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ try {
 
 try {
   execSync(
-    "npm install --save-dev cypress @wordpress/env 10up/cypress-wp-utils#build",
+    "npm install --save-dev cypress@9 @wordpress/env 10up/cypress-wp-utils#build",
     { stdio: "inherit" }
   );
 } catch (e) {


### PR DESCRIPTION
### Description of the Change

Lock Cypress with version 9 until we convert config to version 10

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/cypress-wp-setup/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry

> Changed - Lock Cypress to version 9
