### PR TITLE
Replace `WP_TESTS_DOMAIN` with `WP_SITEURL`

### DIFF
--- a/src/tests/cypress/config.js
+++ b/src/tests/cypress/config.js
@@ -30,7 +30,7 @@ const setBaseUrl = async (on, config) => {
     const port = wpEnvConfig.env.tests.port || null;
 
     if (port) {
-      config.baseUrl = wpEnvConfig.env.tests.config.WP_TESTS_DOMAIN;
+      config.baseUrl = wpEnvConfig.env.tests.config.WP_SITEURL;
     }
   }
 


### PR DESCRIPTION
### Description of the Change
As per https://github.com/WordPress/gutenberg/pull/41039 constant `WP_TESTS_DOMAIN`  restricted to just the hostname and not the home URL, This PR replaces `WP_TESTS_DOMAIN` with `WP_SITEURL` in config to define config.baseUrl with home URL and make it work properly.

<!-- Enter any applicable Issues here. Example: -->
Closes #26 

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected. -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Verification Process
Detailed steps for reproducing the issue are given [here](https://github.com/10up/cypress-wp-setup/issues/26#issue-1378818182)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/cypress-wp-setup/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> Fixed - Test failure due to invalid config.baseUrl.

### Credits

<!-- Please list any and all contributors on this PR and any linked issue so that they can be added to this projects CREDITS.md file. -->
Props @iamdharmesh @oscarssanchez 
