### PR TITLE
Set `chromeWebSecurity` config value to `false` by default

### DIFF
--- a/src/tests/bin/initialize.sh
+++ b/src/tests/bin/initialize.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+npm run env run tests-wordpress chmod -- -c ugo+w /var/www/html
+npm run env run tests-cli wp rewrite structure '/%postname%/' -- --hard

--- a/src/tests/cypress/config.js
+++ b/src/tests/cypress/config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
-const { readConfig }   = require('@wordpress/env/lib/config');
+const { loadConfig } = require( '@wordpress/env/lib/config' );
+const getCacheDirectory = require( '@wordpress/env/lib/config/get-cache-directory' );
 
 module.exports = defineConfig({
   chromeWebSecurity: false,
@@ -25,7 +26,8 @@ module.exports = defineConfig({
  * @returns config Updated Cypress Config object.
  */
 const setBaseUrl = async (on, config) => {
-  const wpEnvConfig = await readConfig('wp-env');
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig( cacheDirectory );
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;

--- a/src/tests/cypress/config.js
+++ b/src/tests/cypress/config.js
@@ -2,6 +2,7 @@ const { defineConfig } = require('cypress');
 const { readConfig }   = require('@wordpress/env/lib/config');
 
 module.exports = defineConfig({
+  chromeWebSecurity: false,
   fixturesFolder: 'tests/cypress/fixtures',
   screenshotsFolder: 'tests/cypress/screenshots',
   videosFolder: 'tests/cypress/videos',
@@ -18,7 +19,7 @@ module.exports = defineConfig({
 
 /**
  * Set WP URL as baseUrl in Cypress config.
- * 
+ *
  * @param {Function} on    function that used to register listeners on various events.
  * @param {object} config  Cypress Config object.
  * @returns config Updated Cypress Config object.


### PR DESCRIPTION
### Description of the Change

Due to changes in WordPress 6.3 that tries to load the block editor in an iframe by default, setting `chromeWebSecurity` to `false` helps avoid errors interacting with that iframe.

In addition, tests were failing due to some changes needed for the latest version of `wp-env`. This has been duplicated from #35 just so tests will pass.

### Alternate Designs

None

### Possible Drawbacks

I'm not aware of any issues with setting this to `false`

### Verification Process

If desired, check out the branch and run the setup process

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/cypress-wp-setup/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Added - Set `chromeWebSecurity` to `false` in our Cypress config

### Credits

Props @dkotter
