### PR TITLE
Add an `env:destroy` command

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ const scripts = {
   "env": "wp-env",
   "env:start": "wp-env start",
   "env:stop": "wp-env stop",
+  "env:destroy": "wp-env destroy",
   "postenv:start": "./tests/bin/initialize.sh",
 };
 

--- a/src/tests/bin/initialize.sh
+++ b/src/tests/bin/initialize.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-npm run env run tests-wordpress "chmod -c ugo+w /var/www/html"
-npm run env run tests-cli "wp rewrite structure '/%postname%/' --hard"
+npm run env run tests-wordpress chmod -- -c ugo+w /var/www/html
+npm run env run tests-cli wp rewrite structure '/%postname%/' -- --hard

--- a/src/tests/cypress/config.js
+++ b/src/tests/cypress/config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require('cypress');
-const { readConfig }   = require('@wordpress/env/lib/config');
+const { loadConfig } = require( '@wordpress/env/lib/config' );
+const getCacheDirectory = require( '@wordpress/env/lib/config/get-cache-directory' );
 
 module.exports = defineConfig({
   fixturesFolder: 'tests/cypress/fixtures',
@@ -18,13 +19,14 @@ module.exports = defineConfig({
 
 /**
  * Set WP URL as baseUrl in Cypress config.
- * 
+ *
  * @param {Function} on    function that used to register listeners on various events.
  * @param {object} config  Cypress Config object.
  * @returns config Updated Cypress Config object.
  */
 const setBaseUrl = async (on, config) => {
-  const wpEnvConfig = await readConfig('wp-env');
+  const cacheDirectory = await getCacheDirectory();
+  const wpEnvConfig = await loadConfig( cacheDirectory );
 
   if (wpEnvConfig) {
     const port = wpEnvConfig.env.tests.port || null;


### PR DESCRIPTION
### Description of the Change

We have commands to start and stop an environment but it's also nice to have a command to destroy an environment once you're done with it. This PR adds that by default to the `package.json` file.

In addition, there were some issues with the newest version of `wp-env` which is installed when this project is used (and during our E2E tests). I didn't intend to fix those things as well but in order to get E2E tests to pass, a few minor changes were required there.

### Alternate Designs

None

### Possible Drawbacks

None

### Verification Process

Check out this branch and set up a new project to ensure the command gets added

### Checklist:

- [x] I have read the [**CONTRIBUTING**](https://github.com/10up/cypress-wp-setup/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [x] All new and existing tests passed.

### Changelog Entry

> Added - New command, `env:destroy` that is used to destroy an environment
> Fixed - Addressed a few issues with the latest version of `wp-env`

### Credits

Props @dkotter
