### PR TITLE
Upgrade Cypress to 13

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ try {
 
 try {
   execSync(
-    "npm install --save-dev cypress@10 @wordpress/env @10up/cypress-wp-utils",
+    "npm install --save-dev cypress@13 @wordpress/env @10up/cypress-wp-utils",
     { stdio: "inherit" }
   );
 } catch (e) {

--- a/src/.github/workflows/cypress.yml
+++ b/src/.github/workflows/cypress.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         core:
           - {name: 'WP latest', version: 'latest'}
-          - {name: 'WP minimum', version: 'WordPress/WordPress#5.2'}
+          - {name: 'WP minimum', version: 'WordPress/WordPress#5.7'}
           - {name: 'WP trunk', version: 'WordPress/WordPress#master'}
     steps:
     - name: Checkout

--- a/src/tests/cypress/e2e/admin.test.js
+++ b/src/tests/cypress/e2e/admin.test.js
@@ -1,5 +1,5 @@
 describe("Admin can login and open dashboard", () => {
-  before(() => {
+  beforeEach(() => {
     cy.login();
   });
 

--- a/src/tests/cypress/support/e2e.js
+++ b/src/tests/cypress/support/e2e.js
@@ -18,9 +18,3 @@ import "@10up/cypress-wp-utils";
 // Import commands.js using ES2015 syntax:
 import "./commands";
 
-// Preserve WP cookies.
-beforeEach(() => {
-  Cypress.Cookies.defaults({
-    preserve: /^wordpress.*?/,
-  });
-});


### PR DESCRIPTION
### Description of the Change
This PR upgrades the Cypress version to 13 and updates needed files as part of the upgrade.

Closes #36

### Alternate Designs
N/A

### Possible Drawbacks
Not any

### Verification Process
Run `npx github:10up/cypress-wp-setup#upkeep/36` in any WP plugin directory and make sure it properly setup the cypress tests in the plugin directory and everything working fine.


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [**CONTRIBUTING**](https://github.com/10up/cypress-wp-setup/blob/develop/CONTRIBUTING.md) document.
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my change.
- [ ] All new and existing tests passed.

<!-- _NOTE: these things are not required to open a PR and can be done afterwards / while the PR is open._ -->

### Changelog Entry
> Changed - Changed - Bump Cypress version from 10.11.0 to 13.0.0

### Credits
Props @iamdharmesh 
